### PR TITLE
Add external link checker and fix broken reference URLs

### DIFF
--- a/.github/workflows/pre-deployment-gates.yml
+++ b/.github/workflows/pre-deployment-gates.yml
@@ -84,6 +84,14 @@ jobs:
         continue-on-error: true 
 
       # ========================================================================
+      # LINK INTEGRITY CHECK
+      # ========================================================================
+      - name: Check external links
+        id: links
+        run: node scripts/check-links.js
+        continue-on-error: true
+
+      # ========================================================================
       # TESTING & TYPES
       # ========================================================================
       - name: Check TypeScript types
@@ -107,6 +115,7 @@ jobs:
           echo "| :--- | :--- |" >> $GITHUB_STEP_SUMMARY
           echo "| 🔍 Secret Scan (TruffleHog) | ${{ steps.trufflehog.outcome == 'success' && '✅ Pass' || '⚠️ Issues Found' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🏗️ DB Lint (Splinter) | ${{ steps.splinter.outcome == 'success' && '✅ Clean' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🔗 External Links | ${{ steps.links.outcome == 'success' && '✅ All Valid' || '⚠️ Broken Links Found' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🟦 Type Safety | ${{ steps.types.outcome == 'success' && '✅ Valid' || '❌ Drift Detected' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🧪 Test Suite | ${{ steps.tests.outcome == 'success' && '✅ All Passed' || '❌ Regressions Found' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/LawnBudAI/lib/lawnAdvice.ts
+++ b/LawnBudAI/lib/lawnAdvice.ts
@@ -300,7 +300,7 @@ export const GERMINATION_INFO: Record<GrassSeedType, GerminationInfo> = {
     maxDays: 12,
     optimalSoilTempMin: 50,
     optimalSoilTempMax: 65,
-    referenceUrl: 'https://extension.psu.edu/lawn-seeding-and-renovation',
+    referenceUrl: 'https://extension.psu.edu/renovation-of-lawns',
   },
   perennial_ryegrass: {
     label: 'Perennial Ryegrass',
@@ -308,7 +308,7 @@ export const GERMINATION_INFO: Record<GrassSeedType, GerminationInfo> = {
     maxDays: 10,
     optimalSoilTempMin: 50,
     optimalSoilTempMax: 65,
-    referenceUrl: 'https://extension.psu.edu/lawn-seeding-and-renovation',
+    referenceUrl: 'https://extension.psu.edu/renovation-of-lawns',
   },
   fine_fescue: {
     label: 'Fine Fescue',
@@ -316,7 +316,7 @@ export const GERMINATION_INFO: Record<GrassSeedType, GerminationInfo> = {
     maxDays: 14,
     optimalSoilTempMin: 50,
     optimalSoilTempMax: 65,
-    referenceUrl: 'https://extension.psu.edu/lawn-seeding-and-renovation',
+    referenceUrl: 'https://extension.psu.edu/renovation-of-lawns',
   },
   bermudagrass: {
     label: 'Bermudagrass',
@@ -577,7 +577,7 @@ export function getOverseedingReminder(
 export const OVERSEEDING_ADVICE_LINKS: Record<GrassType, { label: string; url: string }[]> = {
   cool_season: [
     { label: 'UMN Extension: Seeding & Sodding Home Lawns', url: 'https://extension.umn.edu/lawn-care/seeding-and-sodding-home-lawns' },
-    { label: 'Penn State: Lawn Seeding & Renovation', url: 'https://extension.psu.edu/lawn-seeding-and-renovation' },
+    { label: 'Penn State Extension: Renovation of Lawns', url: 'https://extension.psu.edu/renovation-of-lawns' },
     { label: 'UW-Madison: Lawn Care', url: 'https://hort.extension.wisc.edu/articles/lawn-maintenance/' },
   ],
   warm_season: [
@@ -587,7 +587,7 @@ export const OVERSEEDING_ADVICE_LINKS: Record<GrassType, { label: string; url: s
   ],
   mixed: [
     { label: 'NC State: Carolina Lawns', url: 'https://content.ces.ncsu.edu/carolina-lawns' },
-    { label: 'Penn State: Lawn Seeding & Renovation', url: 'https://extension.psu.edu/lawn-seeding-and-renovation' },
+    { label: 'Penn State Extension: Renovation of Lawns', url: 'https://extension.psu.edu/renovation-of-lawns' },
     { label: 'Clemson Extension: Overseeding with Ryegrass', url: 'https://hgic.clemson.edu/factsheet/overseeding-with-ryegrass/' },
   ],
 };

--- a/LawnBudAI/lib/lawnAdvice.ts
+++ b/LawnBudAI/lib/lawnAdvice.ts
@@ -231,7 +231,7 @@ const fertilizerAdvice: Record<GrassType, Record<Season, LawnAdvice>> = {
 // opportunity is narrow (~6–10 weeks). Windows are based on soil-temperature
 // research from:
 //   - University of Minnesota Extension (cool-season):
-//       https://extension.umn.edu/lawn-care/overseeding-lawns
+//       https://extension.umn.edu/lawn-care/seeding-and-sodding-home-lawns
 //   - Penn State Turfgrass Science (cool-season timing):
 //       https://plantscience.psu.edu/research/centers/turf
 //   - Clemson Extension (warm-season ryegrass overseeding):
@@ -292,7 +292,7 @@ export const GERMINATION_INFO: Record<GrassSeedType, GerminationInfo> = {
     maxDays: 30,
     optimalSoilTempMin: 50,
     optimalSoilTempMax: 65,
-    referenceUrl: 'https://extension.umn.edu/lawn-care/overseeding-lawns',
+    referenceUrl: 'https://extension.umn.edu/lawn-care/seeding-and-sodding-home-lawns',
   },
   tall_fescue: {
     label: 'Tall Fescue',
@@ -364,7 +364,7 @@ export const GERMINATION_INFO: Record<GrassSeedType, GerminationInfo> = {
     maxDays: 21,
     optimalSoilTempMin: 50,
     optimalSoilTempMax: 65,
-    referenceUrl: 'https://extension.umn.edu/lawn-care/overseeding-lawns',
+    referenceUrl: 'https://extension.umn.edu/lawn-care/seeding-and-sodding-home-lawns',
   },
   unknown: {
     label: 'Grass Seed',
@@ -372,7 +372,7 @@ export const GERMINATION_INFO: Record<GrassSeedType, GerminationInfo> = {
     maxDays: 21,
     optimalSoilTempMin: 50,
     optimalSoilTempMax: 65,
-    referenceUrl: 'https://extension.umn.edu/lawn-care/overseeding-lawns',
+    referenceUrl: 'https://extension.umn.edu/lawn-care/seeding-and-sodding-home-lawns',
   },
 };
 
@@ -576,7 +576,7 @@ export function getOverseedingReminder(
  */
 export const OVERSEEDING_ADVICE_LINKS: Record<GrassType, { label: string; url: string }[]> = {
   cool_season: [
-    { label: 'UMN Extension: Overseeding Lawns', url: 'https://extension.umn.edu/lawn-care/overseeding-lawns' },
+    { label: 'UMN Extension: Seeding & Sodding Home Lawns', url: 'https://extension.umn.edu/lawn-care/seeding-and-sodding-home-lawns' },
     { label: 'Penn State: Lawn Seeding & Renovation', url: 'https://extension.psu.edu/lawn-seeding-and-renovation' },
     { label: 'UW-Madison: Lawn Care', url: 'https://hort.extension.wisc.edu/articles/lawn-maintenance/' },
   ],

--- a/LawnBudAI/lib/lawnAdvice.ts
+++ b/LawnBudAI/lib/lawnAdvice.ts
@@ -235,9 +235,9 @@ const fertilizerAdvice: Record<GrassType, Record<Season, LawnAdvice>> = {
 //   - Penn State Turfgrass Science (cool-season timing):
 //       https://plantscience.psu.edu/research/centers/turf
 //   - Clemson Extension (warm-season ryegrass overseeding):
-//       https://hgic.clemson.edu/factsheet/lawn-overseeding/
+//       https://hgic.clemson.edu/factsheet/overseeding-with-ryegrass/
 //   - Texas A&M AgriLife (warm-season ryegrass overseeding):
-//       https://aggie-horticulture.tamu.edu/
+//       https://aggie-hort.tamu.edu/plantanswers/turf/publications/overseed.html
 // ---------------------------------------------------------------------------
 
 export type OverseedingUrgency = 'now' | 'soon';
@@ -324,7 +324,7 @@ export const GERMINATION_INFO: Record<GrassSeedType, GerminationInfo> = {
     maxDays: 30,
     optimalSoilTempMin: 65,
     optimalSoilTempMax: 85,
-    referenceUrl: 'https://aggie-horticulture.tamu.edu/plantanswers/turf/publications/bermuda.html',
+    referenceUrl: 'https://aggie-hort.tamu.edu/plantanswers/turf/publications/Bermuda',
   },
   zoysiagrass: {
     label: 'Zoysiagrass',
@@ -340,7 +340,7 @@ export const GERMINATION_INFO: Record<GrassSeedType, GerminationInfo> = {
     maxDays: 14,
     optimalSoilTempMin: 65,
     optimalSoilTempMax: 85,
-    referenceUrl: 'https://gardeningsolutions.ifas.ufl.edu/lawns/lawn-care/establishing-lawns/',
+    referenceUrl: 'https://gardeningsolutions.ifas.ufl.edu/lawns/maintenance-and-care/planting-your-florida-lawn/',
   },
   centipede: {
     label: 'Centipede Grass',
@@ -356,7 +356,7 @@ export const GERMINATION_INFO: Record<GrassSeedType, GerminationInfo> = {
     maxDays: 7,
     optimalSoilTempMin: 50,
     optimalSoilTempMax: 65,
-    referenceUrl: 'https://aggie-horticulture.tamu.edu/plantanswers/turf/publications/overseed.html',
+    referenceUrl: 'https://aggie-hort.tamu.edu/plantanswers/turf/publications/overseed.html',
   },
   mixed: {
     label: 'Mixed Grass Blend',
@@ -581,14 +581,14 @@ export const OVERSEEDING_ADVICE_LINKS: Record<GrassType, { label: string; url: s
     { label: 'UW-Madison: Lawn Care', url: 'https://hort.extension.wisc.edu/articles/lawn-maintenance/' },
   ],
   warm_season: [
-    { label: 'Texas A&M: Overseeding Warm-Season Turf', url: 'https://aggie-horticulture.tamu.edu/plantanswers/turf/publications/overseed.html' },
-    { label: 'Clemson Extension: Lawn Overseeding', url: 'https://hgic.clemson.edu/factsheet/lawn-overseeding/' },
-    { label: 'UF/IFAS: Establishing Your Florida Lawn', url: 'https://gardeningsolutions.ifas.ufl.edu/lawns/lawn-care/establishing-lawns/' },
+    { label: 'Texas A&M: Overseeding Warm-Season Turf', url: 'https://aggie-hort.tamu.edu/plantanswers/turf/publications/overseed.html' },
+    { label: 'Clemson Extension: Overseeding with Ryegrass', url: 'https://hgic.clemson.edu/factsheet/overseeding-with-ryegrass/' },
+    { label: 'UF/IFAS: Planting Your Florida Lawn', url: 'https://gardeningsolutions.ifas.ufl.edu/lawns/maintenance-and-care/planting-your-florida-lawn/' },
   ],
   mixed: [
-    { label: 'NC State: Overseeding Lawns', url: 'https://content.ces.ncsu.edu/overseeding-lawns' },
+    { label: 'NC State: Carolina Lawns', url: 'https://content.ces.ncsu.edu/carolina-lawns' },
     { label: 'Penn State: Lawn Seeding & Renovation', url: 'https://extension.psu.edu/lawn-seeding-and-renovation' },
-    { label: 'Clemson Extension: Lawn Overseeding', url: 'https://hgic.clemson.edu/factsheet/lawn-overseeding/' },
+    { label: 'Clemson Extension: Overseeding with Ryegrass', url: 'https://hgic.clemson.edu/factsheet/overseeding-with-ryegrass/' },
   ],
 };
 

--- a/LawnBudAI/package.json
+++ b/LawnBudAI/package.json
@@ -22,6 +22,7 @@
     "test:playwright:ui": "playwright test --ui",
     "test:maestro": "maestro test .maestro/",
     "validate:schema": "node scripts/validate-schema.js",
+    "check:links": "node scripts/check-links.js",
     "db:lint": "supabase db lint --level warning --fail-on warning --schema public",
     "db:lint:linked": "supabase link --project-ref $SUPABASE_PROJECT_ID && supabase db lint --linked --level warning --fail-on warning --schema public",
     "types:generate": "supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > types/database.types.ts",

--- a/LawnBudAI/scripts/check-links.js
+++ b/LawnBudAI/scripts/check-links.js
@@ -50,6 +50,20 @@ const BROKEN_STATUSES = new Set([404, 410]);
 /** HTTP status codes treated as soft warnings (bot-blocking, not truly broken) */
 const WARN_STATUSES = new Set([403, 429]);
 
+/**
+ * Domains that return 403 for ALL requests (bot AND browser UA) regardless of
+ * whether the page exists. The browser-UA retry cannot distinguish a live page
+ * from a deleted one on these hosts, so any 403 from them is escalated to a
+ * hard warning requiring manual verification rather than silently passing.
+ *
+ * Add a domain here when you confirm it returns 403 even to real browsers for
+ * pages that do not exist.
+ */
+const OPAQUE_403_DOMAINS = new Set([
+  'extension.umn.edu',
+  'extension.psu.edu',
+]);
+
 const REQUEST_TIMEOUT_MS = 12000;
 const CONCURRENCY = 4; // parallel fetch limit
 
@@ -150,7 +164,12 @@ async function fetchWithTimeout(url, method, ua) {
   }
 }
 
+function domainOf(url) {
+  try { return new URL(url).hostname; } catch { return ''; }
+}
+
 async function checkUrl(url) {
+  const domain = domainOf(url);
   try {
     // Step 1: HEAD with bot UA (fast path for well-behaved servers)
     let res = await fetchWithTimeout(url, 'HEAD', BOT_UA);
@@ -160,18 +179,21 @@ async function checkUrl(url) {
       res = await fetchWithTimeout(url, 'GET', BOT_UA);
     }
 
-    // Step 3: If still 403, retry with a browser UA.
-    //
-    // Rationale: sites like extension.umn.edu return 403 to bots for BOTH
-    // existing and deleted pages.  With a real browser UA they return 200 for
-    // live pages and redirect/404 for missing ones, letting us tell the
-    // difference.
     if (res.status === 403) {
+      // Step 3a: Domains in OPAQUE_403_DOMAINS return 403 even to real browsers
+      // for missing pages — the browser-UA retry cannot tell live from deleted.
+      // Escalate to a hard warning so the operator must verify manually.
+      if (OPAQUE_403_DOMAINS.has(domain)) {
+        return { status: 403, finalUrl: res.url, opaque403: true };
+      }
+
+      // Step 3b: For other domains, retry with a browser UA.
+      // If the page exists they return 200; if deleted they return 404/410 or
+      // stay 403 (still unresolvable, falls through to soft-warn).
       let retryRes;
       try {
         retryRes = await fetchWithTimeout(url, 'GET', BROWSER_UA);
       } catch {
-        // Network error on retry — keep the original 403 result
         return { status: 403, finalUrl: res.url };
       }
 
@@ -179,7 +201,6 @@ async function checkUrl(url) {
         // Page exists — bot-blocking only, not truly broken
         return { status: retryRes.status, finalUrl: retryRes.url, botBlocked: true };
       }
-      // 404, 410, or another 403 on the browser retry
       return { status: retryRes.status, finalUrl: retryRes.url };
     }
 
@@ -254,14 +275,17 @@ async function main() {
 
   // Categorise results
   const broken = [];
+  const opaque = [];   // 403 from domains that block bots AND browsers equally
   const warnings = [];
   const ok = [];
 
   for (const r of results) {
     if (r.error || BROKEN_STATUSES.has(r.status)) {
       broken.push(r);
+    } else if (r.opaque403) {
+      // Unresolvable 403 from a known opaque domain — must verify manually
+      opaque.push(r);
     } else if (WARN_STATUSES.has(r.status) && !r.botBlocked) {
-      // 403/429 that persisted even with a browser UA = truly unresolvable
       warnings.push(r);
     } else {
       ok.push(r);
@@ -271,6 +295,16 @@ async function main() {
   // Report
   if (ok.length > 0) {
     console.log(`✅ ${ok.length} link(s) OK`);
+  }
+
+  if (opaque.length > 0) {
+    console.log(`\n🔶 ${opaque.length} link(s) need MANUAL verification (domain blocks all bots — cannot auto-detect broken pages):`);
+    for (const r of opaque) {
+      console.log(`   [403/opaque] ${r.url}`);
+      console.log(`         in: ${r.files.join(', ')}`);
+    }
+    console.log(`\n   Add these to OPAQUE_403_DOMAINS in scripts/check-links.js once verified,`);
+    console.log(`   or fix/remove the URL if the page is gone.\n`);
   }
 
   if (warnings.length > 0) {
@@ -289,6 +323,9 @@ async function main() {
       console.log(`         in: ${r.files.join(', ')}`);
     }
     console.log();
+  }
+
+  if (broken.length > 0 || opaque.length > 0) {
     process.exit(1);
   }
 

--- a/LawnBudAI/scripts/check-links.js
+++ b/LawnBudAI/scripts/check-links.js
@@ -115,42 +115,76 @@ function shouldSkip(url) {
 // HTTP checking
 // ---------------------------------------------------------------------------
 
-async function checkUrl(url) {
+/**
+ * Full browser User-Agent used for 403-retry requests.
+ *
+ * Some university extension sites (e.g. extension.umn.edu) return 403 for
+ * ALL bot requests, whether the page exists or not, making it impossible to
+ * distinguish a live-but-blocked page from a deleted one.  Retrying with a
+ * browser UA string resolves this for most of those servers: if the page
+ * exists they return 200; if it doesn't they still return 403 or redirect to
+ * a generic error page (different final URL).
+ */
+const BROWSER_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+
+const BOT_UA =
+  'Mozilla/5.0 (compatible; LawnBudAI-LinkChecker/1.0; +https://github.com/HaulinLogs/lawnbudai)';
+
+async function fetchWithTimeout(url, method, ua) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-
   try {
-    // Try HEAD first (faster, no body)
-    let res = await fetch(url, {
-      method: 'HEAD',
+    const res = await fetch(url, {
+      method,
       signal: controller.signal,
-      headers: {
-        'User-Agent':
-          'Mozilla/5.0 (compatible; LawnBudAI-LinkChecker/1.0; +https://github.com/HaulinLogs/lawnbudai)',
-      },
+      headers: { 'User-Agent': ua },
       redirect: 'follow',
     });
-
-    // Some servers reject HEAD but accept GET — retry with GET on 405
-    if (res.status === 405) {
-      const controller2 = new AbortController();
-      const timer2 = setTimeout(() => controller2.abort(), REQUEST_TIMEOUT_MS);
-      res = await fetch(url, {
-        method: 'GET',
-        signal: controller2.signal,
-        headers: {
-          'User-Agent':
-            'Mozilla/5.0 (compatible; LawnBudAI-LinkChecker/1.0; +https://github.com/HaulinLogs/lawnbudai)',
-        },
-        redirect: 'follow',
-      });
-      clearTimeout(timer2);
-    }
-
     clearTimeout(timer);
-    return { status: res.status, finalUrl: res.url };
+    return res;
   } catch (err) {
     clearTimeout(timer);
+    throw err;
+  }
+}
+
+async function checkUrl(url) {
+  try {
+    // Step 1: HEAD with bot UA (fast path for well-behaved servers)
+    let res = await fetchWithTimeout(url, 'HEAD', BOT_UA);
+
+    // Step 2: Some servers reject HEAD → retry with GET
+    if (res.status === 405) {
+      res = await fetchWithTimeout(url, 'GET', BOT_UA);
+    }
+
+    // Step 3: If still 403, retry with a browser UA.
+    //
+    // Rationale: sites like extension.umn.edu return 403 to bots for BOTH
+    // existing and deleted pages.  With a real browser UA they return 200 for
+    // live pages and redirect/404 for missing ones, letting us tell the
+    // difference.
+    if (res.status === 403) {
+      let retryRes;
+      try {
+        retryRes = await fetchWithTimeout(url, 'GET', BROWSER_UA);
+      } catch {
+        // Network error on retry — keep the original 403 result
+        return { status: 403, finalUrl: res.url };
+      }
+
+      if (retryRes.status === 200 || (retryRes.status >= 300 && retryRes.status < 400)) {
+        // Page exists — bot-blocking only, not truly broken
+        return { status: retryRes.status, finalUrl: retryRes.url, botBlocked: true };
+      }
+      // 404, 410, or another 403 on the browser retry
+      return { status: retryRes.status, finalUrl: retryRes.url };
+    }
+
+    return { status: res.status, finalUrl: res.url };
+  } catch (err) {
     const message = err.name === 'AbortError' ? 'timeout' : err.message;
     return { status: 0, error: message };
   }
@@ -226,7 +260,8 @@ async function main() {
   for (const r of results) {
     if (r.error || BROKEN_STATUSES.has(r.status)) {
       broken.push(r);
-    } else if (WARN_STATUSES.has(r.status)) {
+    } else if (WARN_STATUSES.has(r.status) && !r.botBlocked) {
+      // 403/429 that persisted even with a browser UA = truly unresolvable
       warnings.push(r);
     } else {
       ok.push(r);

--- a/LawnBudAI/scripts/check-links.js
+++ b/LawnBudAI/scripts/check-links.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+
+/**
+ * External Link Checker
+ *
+ * Scans all TypeScript/JavaScript source files for external URLs embedded in
+ * string literals and verifies each one returns a non-broken HTTP response.
+ *
+ * Exit codes:
+ *   0 = All links valid (or only soft warnings)
+ *   1 = One or more links confirmed broken (404 / 410 / connection error)
+ *
+ * Run: node scripts/check-links.js
+ * CI:  yarn check:links
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Directories to skip entirely */
+const SKIP_DIRS = new Set(['node_modules', '.yarn', '.expo', 'dist', 'build', '.git']);
+
+/** File extensions to scan */
+const SCAN_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+
+/** Skip test files — their URLs are fixtures, not real links */
+const SKIP_PATH_PATTERNS = [/__tests__/, /\.test\./, /\.spec\./, /playwright\.config/];
+
+/** URL patterns that are never real links */
+const SKIP_URL_PATTERNS = [
+  /^https?:\/\/localhost/,
+  /^https?:\/\/127\./,
+  /^https?:\/\/0\.0\.0\.0/,
+  /^https?:\/\/example\.com/,
+  /your-project\.supabase\.co/,
+  /YOUR_PROJECT\.supabase\.co/,
+  /test\.supabase\.co/,
+  /\$\{/,                     // dynamic template literal segments
+];
+
+/** HTTP status codes that confirm a link is broken */
+const BROKEN_STATUSES = new Set([404, 410]);
+
+/** HTTP status codes treated as soft warnings (bot-blocking, not truly broken) */
+const WARN_STATUSES = new Set([403, 429]);
+
+const REQUEST_TIMEOUT_MS = 12000;
+const CONCURRENCY = 4; // parallel fetch limit
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+function walkDir(dir, results = []) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      walkDir(fullPath, results);
+    } else if (SCAN_EXTENSIONS.has(path.extname(entry.name))) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// URL extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract URLs that appear inside string literals (single, double, or
+ * template-literal quotes). Skips pure-comment lines to reduce noise.
+ */
+function extractUrlsFromFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const urls = [];
+
+  // Match URLs inside quoted strings only (not bare comments)
+  // Captures the URL up to the closing quote or whitespace
+  const pattern = /['"`](https?:\/\/[^'"`\s\\>)]+)['"`]/g;
+
+  let match;
+  while ((match = pattern.exec(content)) !== null) {
+    const url = match[1].replace(/[.,;]$/, ''); // strip trailing punctuation
+    if (!shouldSkip(url)) {
+      urls.push(url);
+    }
+  }
+
+  return urls;
+}
+
+function shouldSkip(url) {
+  return SKIP_URL_PATTERNS.some(re => re.test(url));
+}
+
+// ---------------------------------------------------------------------------
+// HTTP checking
+// ---------------------------------------------------------------------------
+
+async function checkUrl(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    // Try HEAD first (faster, no body)
+    let res = await fetch(url, {
+      method: 'HEAD',
+      signal: controller.signal,
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (compatible; LawnBudAI-LinkChecker/1.0; +https://github.com/HaulinLogs/lawnbudai)',
+      },
+      redirect: 'follow',
+    });
+
+    // Some servers reject HEAD but accept GET — retry with GET on 405
+    if (res.status === 405) {
+      const controller2 = new AbortController();
+      const timer2 = setTimeout(() => controller2.abort(), REQUEST_TIMEOUT_MS);
+      res = await fetch(url, {
+        method: 'GET',
+        signal: controller2.signal,
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (compatible; LawnBudAI-LinkChecker/1.0; +https://github.com/HaulinLogs/lawnbudai)',
+        },
+        redirect: 'follow',
+      });
+      clearTimeout(timer2);
+    }
+
+    clearTimeout(timer);
+    return { status: res.status, finalUrl: res.url };
+  } catch (err) {
+    clearTimeout(timer);
+    const message = err.name === 'AbortError' ? 'timeout' : err.message;
+    return { status: 0, error: message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency helper
+// ---------------------------------------------------------------------------
+
+async function runWithConcurrency(tasks, limit) {
+  const results = [];
+  let index = 0;
+
+  async function worker() {
+    while (index < tasks.length) {
+      const i = index++;
+      results[i] = await tasks[i]();
+    }
+  }
+
+  await Promise.all(Array.from({ length: limit }, worker));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const rootDir = process.cwd();
+  console.log(`\n🔗 LawnBudAI Link Checker — scanning ${rootDir}\n`);
+
+  // Collect all source files
+  const files = walkDir(rootDir).filter(
+    f => !SKIP_PATH_PATTERNS.some(re => re.test(f))
+  );
+
+  // Extract unique URLs and track which files reference them
+  const urlMap = new Map(); // url → Set<filePath>
+  for (const file of files) {
+    const urls = extractUrlsFromFile(file);
+    for (const url of urls) {
+      if (!urlMap.has(url)) urlMap.set(url, new Set());
+      urlMap.get(url).add(path.relative(rootDir, file));
+    }
+  }
+
+  const uniqueUrls = [...urlMap.keys()];
+  console.log(`Found ${uniqueUrls.length} unique external URL(s) across ${files.length} file(s)\n`);
+
+  if (uniqueUrls.length === 0) {
+    console.log('✅ No external links to check.\n');
+    process.exit(0);
+  }
+
+  // Check all URLs with bounded concurrency
+  const tasks = uniqueUrls.map(url => async () => {
+    const result = await checkUrl(url);
+    return { url, ...result, files: [...urlMap.get(url)] };
+  });
+
+  process.stdout.write('Checking');
+  const interval = setInterval(() => process.stdout.write('.'), 1000);
+  const results = await runWithConcurrency(tasks, CONCURRENCY);
+  clearInterval(interval);
+  console.log('\n');
+
+  // Categorise results
+  const broken = [];
+  const warnings = [];
+  const ok = [];
+
+  for (const r of results) {
+    if (r.error || BROKEN_STATUSES.has(r.status)) {
+      broken.push(r);
+    } else if (WARN_STATUSES.has(r.status)) {
+      warnings.push(r);
+    } else {
+      ok.push(r);
+    }
+  }
+
+  // Report
+  if (ok.length > 0) {
+    console.log(`✅ ${ok.length} link(s) OK`);
+  }
+
+  if (warnings.length > 0) {
+    console.log(`\n⚠️  ${warnings.length} link(s) returned ${[...WARN_STATUSES].join('/')} (likely bot-blocking, verify manually):`);
+    for (const r of warnings) {
+      console.log(`   [${r.status}] ${r.url}`);
+      console.log(`         in: ${r.files.join(', ')}`);
+    }
+  }
+
+  if (broken.length > 0) {
+    console.log(`\n❌ ${broken.length} BROKEN link(s) found — fix before merging:\n`);
+    for (const r of broken) {
+      const status = r.error ? `ERROR (${r.error})` : r.status;
+      console.log(`   [${status}] ${r.url}`);
+      console.log(`         in: ${r.files.join(', ')}`);
+    }
+    console.log();
+    process.exit(1);
+  }
+
+  console.log('\n✅ All external links are valid.\n');
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('Link checker crashed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
This PR introduces an automated external link checker script and fixes broken URLs in the lawn advice reference documentation.

## Key Changes

### New Link Checker Script (`scripts/check-links.js`)
- **Automated URL validation**: Scans all TypeScript/JavaScript source files for embedded HTTP(S) URLs and verifies they return valid responses
- **Smart HTTP handling**: 
  - Uses HEAD requests with bot User-Agent for efficiency, falls back to GET if needed
  - Retries 403 responses with a browser User-Agent to distinguish bot-blocking from genuinely broken pages
  - Handles opaque 403 domains (e.g., university extension sites) that block all requests equally, requiring manual verification
- **Intelligent categorization**:
  - Hard failures: 404, 410, connection errors (exit code 1)
  - Soft warnings: 403/429 responses that may indicate bot-blocking (reported but don't fail CI)
  - Opaque 403s: Flagged for manual verification when from known problematic domains
- **Configurable filtering**: Skips test files, localhost URLs, template literals, and example domains
- **Concurrent checking**: Limits parallel requests to 4 to avoid overwhelming servers
- **CI integration**: Added to pre-deployment-gates workflow and package.json scripts

### Fixed Reference URLs in `lib/lawnAdvice.ts`
Updated broken or outdated extension service URLs to current valid endpoints:
- University of Minnesota Extension: `overseeding-lawns` → `seeding-and-sodding-home-lawns`
- Penn State Extension: `lawn-seeding-and-renovation` → `renovation-of-lawns`
- Clemson Extension: `lawn-overseeding/` → `overseeding-with-ryegrass/`
- Texas A&M AgriLife: `aggie-horticulture.tamu.edu` → `aggie-hort.tamu.edu` (domain change)
- UF/IFAS: Updated to current lawn planting guide URL
- Updated all corresponding references in `GERMINATION_INFO` and `OVERSEEDING_ADVICE_LINKS` objects

### CI/CD Updates
- Added link checker step to pre-deployment-gates workflow
- Added `check:links` npm script for local validation
- Integrated results into workflow summary report

## Implementation Details
- Exit code 0 for all valid links or soft warnings only
- Exit code 1 for confirmed broken links or unresolvable opaque 403s
- 12-second timeout per request with graceful error handling
- Deduplicates URLs across codebase and tracks which files reference each URL
- Provides detailed reporting with file locations for easy remediation

https://claude.ai/code/session_01BFmx58X5gTN5RJ8zkWDuHG